### PR TITLE
Change to logic to skip the param in path building when the param is not...

### DIFF
--- a/src/TccSkippableSegment/Mvc/Router/Http/SkippableSegment.php
+++ b/src/TccSkippableSegment/Mvc/Router/Http/SkippableSegment.php
@@ -104,7 +104,8 @@ class SkippableSegment extends Segment
                 case 'parameter':
                     $skippable = true;
 
-                    if (!empty($this->skippable[$part[1]]) && (!isset($mergedParams[$part[1]]) || !isset($this->defaults[$part[1]]) || $mergedParams[$part[1]] === $this->defaults[$part[1]])) {
+                    if (!empty($this->skippable[$part[1]]) && (!isset($mergedParams[$part[1]]) || 
+                            array_key_exists($part[1], $this->defaults) && $mergedParams[$part[1]] === $this->defaults[$part[1]])) {
                         $this->assembledParams[] = $part[1];
                         break;
                     } elseif (!isset($mergedParams[$part[1]])) {


### PR DESCRIPTION
... set and skippable, or, it is set and it doesn't match the default. (Previous behavior skipped the param if no default was set, regardless of whether the param was passed.)
